### PR TITLE
Release GIL around FFTW planning

### DIFF
--- a/pyfftw/pyfftw.pxd
+++ b/pyfftw/pyfftw.pxd
@@ -79,63 +79,63 @@ cdef extern from 'fftw3.h':
             int rank, fftw_iodim *dims,
             int howmany_rank, fftw_iodim *howmany_dims,
             cdouble *_in, cdouble *_out,
-            int sign, unsigned flags)
+            int sign, unsigned flags) nogil
     
     # Single precision complex planner
     fftwf_plan fftwf_plan_guru_dft(
             int rank, fftw_iodim *dims,
             int howmany_rank, fftw_iodim *howmany_dims,
             cfloat *_in, cfloat *_out,
-            int sign, unsigned flags)
+            int sign, unsigned flags) nogil
 
     # Single precision complex planner
     fftwl_plan fftwl_plan_guru_dft(
             int rank, fftw_iodim *dims,
             int howmany_rank, fftw_iodim *howmany_dims,
             clongdouble *_in, clongdouble *_out,
-            int sign, unsigned flags)
+            int sign, unsigned flags) nogil
     
     # Double precision real to complex planner
     fftw_plan fftw_plan_guru_dft_r2c(
             int rank, fftw_iodim *dims,
             int howmany_rank, fftw_iodim *howmany_dims,
             double *_in, cdouble *_out,
-            unsigned flags)
+            unsigned flags) nogil
     
     # Single precision real to complex planner
     fftwf_plan fftwf_plan_guru_dft_r2c(
             int rank, fftw_iodim *dims,
             int howmany_rank, fftw_iodim *howmany_dims,
             float *_in, cfloat *_out,
-            unsigned flags)
+            unsigned flags) nogil
 
     # Single precision real to complex planner
     fftwl_plan fftwl_plan_guru_dft_r2c(
             int rank, fftw_iodim *dims,
             int howmany_rank, fftw_iodim *howmany_dims,
             long double *_in, clongdouble *_out,
-            unsigned flags)
+            unsigned flags) nogil
 
     # Double precision complex to real planner
     fftw_plan fftw_plan_guru_dft_c2r(
             int rank, fftw_iodim *dims,
             int howmany_rank, fftw_iodim *howmany_dims,
             cdouble *_in, double *_out,
-            unsigned flags)
+            unsigned flags) nogil
     
     # Single precision complex to real planner
     fftwf_plan fftwf_plan_guru_dft_c2r(
             int rank, fftw_iodim *dims,
             int howmany_rank, fftw_iodim *howmany_dims,
             cfloat *_in, float *_out,
-            unsigned flags)
+            unsigned flags) nogil
 
     # Single precision complex to real planner
     fftwl_plan fftwl_plan_guru_dft_c2r(
             int rank, fftw_iodim *dims,
             int howmany_rank, fftw_iodim *howmany_dims,
             clongdouble *_in, long double *_out,
-            unsigned flags)
+            unsigned flags) nogil
 
     # Double precision complex new array execute
     void fftw_execute_dft(fftw_plan,
@@ -243,7 +243,7 @@ ctypedef void * (*fftw_generic_plan_guru)(
         int rank, fftw_iodim *dims,
         int howmany_rank, fftw_iodim *howmany_dims,
         void *_in, void *_out,
-        int sign, int flags)
+        int sign, int flags) nogil
 
 ctypedef void (*fftw_generic_execute)(void *_plan, void *_in, void *_out) nogil
 

--- a/pyfftw/pyfftw.pyx
+++ b/pyfftw/pyfftw.pyx
@@ -1101,13 +1101,11 @@ cdef class FFTW:
         cdef void *_in = <void *>np.PyArray_DATA(self._input_array)
         cdef void *_out = <void *>np.PyArray_DATA(self._output_array)
         cdef int sign = self._direction
-        cdef int c_flags = self._flags
-        
-        plan_lock.acquire()
-        with nogil:
-            plan = fftw_planner(rank, dims, howmany_rank, howmany_dims, 
-                _in, _out, sign, c_flags)
-        plan_lock.release()
+        cdef unsigned c_flags = self._flags
+
+        with plan_lock, nogil:
+            plan = fftw_planner(rank, dims, howmany_rank, howmany_dims,
+                                _in, _out, sign, c_flags)
         self._plan = plan
         
         if self._plan == NULL:

--- a/pyfftw/pyfftw.pyx
+++ b/pyfftw/pyfftw.pyx
@@ -1062,7 +1062,7 @@ cdef class FFTW:
         else:
             fft_shape = fft_shape_lookup(input_array, output_array)
 
-        # Fillstride and shape information
+        # Fill in the stride and shape information
         input_strides_array = self._input_item_strides
         output_strides_array = self._output_item_strides
         for i in range(0, self._rank):

--- a/pyfftw/pyfftw.pyx
+++ b/pyfftw/pyfftw.pyx
@@ -66,7 +66,7 @@ _flag_dict = flag_dict.copy()
 
 # Need a global lock to protect FFTW planning so that multiple Python threads
 # do not attempt to plan simultaneously.
-PLAN_LOCK = threading.Lock()
+cdef object plan_lock = threading.Lock()
 
 # Function wrappers
 # =================
@@ -1103,11 +1103,11 @@ cdef class FFTW:
         cdef int sign = self._direction
         cdef int c_flags = self._flags
         
-        PLAN_LOCK.acquire()
+        plan_lock.acquire()
         with nogil:
             plan = fftw_planner(rank, dims, howmany_rank, howmany_dims, 
                 _in, _out, sign, c_flags)
-        PLAN_LOCK.release()
+        plan_lock.release()
         self._plan = plan
         
         if self._plan == NULL:


### PR DESCRIPTION
Instead acquire a python-level lock to keep multiple threads from planning simultaneously. Addresses Issue #75.