### PR TITLE
Support FFTW_WISDOM_ONLY (cleaned up patch)

### DIFF
--- a/pyfftw/pyfftw.pxd
+++ b/pyfftw/pyfftw.pxd
@@ -243,7 +243,7 @@ ctypedef void * (*fftw_generic_plan_guru)(
         int rank, fftw_iodim *dims,
         int howmany_rank, fftw_iodim *howmany_dims,
         void *_in, void *_out,
-        int sign, int flags)
+        int sign, unsigned flags)
 
 ctypedef void (*fftw_generic_execute)(void *_plan, void *_in, void *_out) nogil
 
@@ -274,4 +274,4 @@ cdef enum:
     FFTW_PRESERVE_INPUT = 16
     FFTW_PATIENT = 32
     FFTW_ESTIMATE = 64
-
+    FFTW_WISDOM_ONLY = 2097152

--- a/pyfftw/pyfftw.pyx
+++ b/pyfftw/pyfftw.pyx
@@ -59,7 +59,8 @@ flag_dict = {'FFTW_MEASURE': FFTW_MEASURE,
         'FFTW_PATIENT': FFTW_PATIENT,
         'FFTW_ESTIMATE': FFTW_ESTIMATE,
         'FFTW_UNALIGNED': FFTW_UNALIGNED,
-        'FFTW_DESTROY_INPUT': FFTW_DESTROY_INPUT}
+        'FFTW_DESTROY_INPUT': FFTW_DESTROY_INPUT,
+        'FFTW_WISDOM_ONLY': FFTW_WISDOM_ONLY}
 
 _flag_dict = flag_dict.copy()
 
@@ -80,7 +81,7 @@ cdef void* _fftw_plan_guru_dft(
             int rank, fftw_iodim *dims,
             int howmany_rank, fftw_iodim *howmany_dims,
             void *_in, void *_out,
-            int sign, int flags):
+            int sign, unsigned flags):
 
     return <void *>fftw_plan_guru_dft(rank, dims,
             howmany_rank, howmany_dims,
@@ -92,7 +93,7 @@ cdef void* _fftwf_plan_guru_dft(
             int rank, fftw_iodim *dims,
             int howmany_rank, fftw_iodim *howmany_dims,
             void *_in, void *_out,
-            int sign, int flags):
+            int sign, unsigned flags):
 
     return <void *>fftwf_plan_guru_dft(rank, dims,
             howmany_rank, howmany_dims,
@@ -104,7 +105,7 @@ cdef void* _fftwl_plan_guru_dft(
             int rank, fftw_iodim *dims,
             int howmany_rank, fftw_iodim *howmany_dims,
             void *_in, void *_out,
-            int sign, int flags):
+            int sign, unsigned flags):
 
     return <void *>fftwl_plan_guru_dft(rank, dims,
             howmany_rank, howmany_dims,
@@ -116,7 +117,7 @@ cdef void* _fftw_plan_guru_dft_r2c(
             int rank, fftw_iodim *dims,
             int howmany_rank, fftw_iodim *howmany_dims,
             void *_in, void *_out,
-            int sign, int flags):
+            int sign, unsigned flags):
 
     return <void *>fftw_plan_guru_dft_r2c(rank, dims,
             howmany_rank, howmany_dims,
@@ -128,7 +129,7 @@ cdef void* _fftwf_plan_guru_dft_r2c(
             int rank, fftw_iodim *dims,
             int howmany_rank, fftw_iodim *howmany_dims,
             void *_in, void *_out,
-            int sign, int flags):
+            int sign, unsigned flags):
 
     return <void *>fftwf_plan_guru_dft_r2c(rank, dims,
             howmany_rank, howmany_dims,
@@ -140,7 +141,7 @@ cdef void* _fftwl_plan_guru_dft_r2c(
             int rank, fftw_iodim *dims,
             int howmany_rank, fftw_iodim *howmany_dims,
             void *_in, void *_out,
-            int sign, int flags):
+            int sign, unsigned flags):
 
     return <void *>fftwl_plan_guru_dft_r2c(rank, dims,
             howmany_rank, howmany_dims,
@@ -152,7 +153,7 @@ cdef void* _fftw_plan_guru_dft_c2r(
             int rank, fftw_iodim *dims,
             int howmany_rank, fftw_iodim *howmany_dims,
             void *_in, void *_out,
-            int sign, int flags):
+            int sign, unsigned flags):
 
     return <void *>fftw_plan_guru_dft_c2r(rank, dims,
             howmany_rank, howmany_dims,
@@ -164,7 +165,7 @@ cdef void* _fftwf_plan_guru_dft_c2r(
             int rank, fftw_iodim *dims,
             int howmany_rank, fftw_iodim *howmany_dims,
             void *_in, void *_out,
-            int sign, int flags):
+            int sign, unsigned flags):
 
     return <void *>fftwf_plan_guru_dft_c2r(rank, dims,
             howmany_rank, howmany_dims,
@@ -176,7 +177,7 @@ cdef void* _fftwl_plan_guru_dft_c2r(
             int rank, fftw_iodim *dims,
             int howmany_rank, fftw_iodim *howmany_dims,
             void *_in, void *_out,
-            int sign, int flags):
+            int sign, unsigned flags):
 
     return <void *>fftwl_plan_guru_dft_c2r(rank, dims,
             howmany_rank, howmany_dims,
@@ -631,7 +632,7 @@ cdef class FFTW:
     cdef np.ndarray _input_array
     cdef np.ndarray _output_array
     cdef int _direction
-    cdef int _flags
+    cdef unsigned _flags
 
     cdef bint _simd_allowed
     cdef int _input_array_alignment
@@ -1091,7 +1092,10 @@ cdef class FFTW:
             self._direction, self._flags)
 
         if self._plan == NULL:
-            raise RuntimeError('The data has an uncaught error that led '+
+            if 'FFTW_WISDOM_ONLY' in flags:
+                raise RuntimeError('No FFTW wisdom is known for this plan.')
+            else:
+                raise RuntimeError('The data has an uncaught error that led '+
                     'to the planner returning NULL. This is a bug.')
 
     def __init__(self, input_array, output_array, axes=(-1,), 
@@ -1152,6 +1156,23 @@ cdef class FFTW:
             possible to preserve the input, making this flag implicit
             in that case. A little more on this is given 
             :ref:`below<scheme_table>`.
+          * ``'FFTW_WISDOM_ONLY'`` is supported.
+            This tells FFTW to raise an error if no plan for this transform
+            and data type is already in the wisdom. It thus provides a method
+            to determine whether planning would require additional effor or the
+            cached wisdom can be used. This flag should be combined with the
+            various planning-effort flags (``'FFTW_ESTIMATE'``,
+            ``'FFTW_MEASURE'``, etc.); if so, then an error will be raised if
+            wisdom derived from that level of planning effort (or higher) is 
+            not present. If no planning-effort flag is used, the default of
+            ``'FFTW_ESTIMATE'`` is assumed.
+            Note that wisdom is specific to all the parameters, including the
+            data alignment. That is, if wisdom was generated with input/output
+            arrays with one specific alignment, using ``'FFTW_WISDOM_ONLY'``
+            to create a plan for arrays with any different alignment will 
+            cause the ``'FFTW_WISDOM_ONLY'`` planning to fail. Thus it is
+            important to specifically control the data alignment to make the
+            best use of ``'FFTW_WISDOM_ONLY'``.
 
           The `FFTW planner flags documentation 
           <http://www.fftw.org/fftw3_doc/Planner-Flags.html#Planner-Flags>`_

--- a/test/test_pyfftw_complex.py
+++ b/test/test_pyfftw_complex.py
@@ -178,6 +178,8 @@ class Complex64FFTW1DTest(object):
         a, b = self.create_test_arrays(in_shape, out_shape)
 
         for each_flag in pyfftw.pyfftw._flag_dict:
+            if each_flag == 'FFTW_WISDOM_ONLY':
+                continue
             fft, ifft = self.run_validate_fft(a, b, axes, 
                     flags=(each_flag,))
 
@@ -187,6 +189,30 @@ class Complex64FFTW1DTest(object):
         # also, test no flags (which should still work)
         fft, ifft = self.run_validate_fft(a, b, axes, 
                     flags=())
+
+    def test_wisdom_only(self):
+        in_shape = self.input_shapes['small_1d']
+        out_shape = self.output_shapes['small_1d']
+
+        axes=(0,)
+        a, b = self.create_test_arrays(in_shape, out_shape)
+        forget_wisdom()
+        # with no wisdom, an error should be raised with FFTW_WISDOM_ONLY
+        # 
+        # NB: wisdom is specific to aligned/unaligned distinction, so we must
+        # ensure that the arrays don't get copied (and potentially
+        # switched between aligned and unaligned) by run_validate_fft()... 
+        self.assertRaisesRegex(RuntimeError, 'No FFTW wisdom', 
+                self.run_validate_fft, *(a, b, axes), 
+                **{'flags':('FFTW_ESTIMATE', 'FFTW_WISDOM_ONLY'), 
+                   'create_array_copies': False})
+        # now plan the FFT
+        self.run_validate_fft(a, b, axes, flags=('FFTW_ESTIMATE',),
+                create_array_copies=False)
+        # now FFTW_WISDOM_ONLY should not raise an error because the plan should
+        # be in the wisdom
+        self.run_validate_fft(a, b, axes, flags=('FFTW_ESTIMATE', 
+                'FFTW_WISDOM_ONLY'), create_array_copies=False)
 
     def test_destroy_input(self):
         '''Test the destroy input flag


### PR DESCRIPTION
Add support and tests for the FFTW_WISDOM_ONLY planning flag, and also address potential type incompatibilities between FFTW.h and pyfftw (int vs. unsigned for the FFTW flags parameter).